### PR TITLE
fixed env var in tftp boot description

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ transfer image.fit through TFTP:
 Step1: set enviroment parameter:
 
 ```
-setenv 192.168.xxx.xxx; setenv serverip 192.168.xxx.xxx;
+setenv ipaddr 192.168.xxx.xxx; setenv serverip 192.168.xxx.xxx;
 ```
 
 Step2: upload image file to ddr:


### PR DESCRIPTION
I tried to follow the tftp boot sequence from the README. Without setting the `ipaddr` environment variable, `tftpboot ${loadaddr} image.fit;` fails with ``*** ERROR: `ipaddr' not set``